### PR TITLE
Export `solveCaptcha`

### DIFF
--- a/hcaptcha.js
+++ b/hcaptcha.js
@@ -399,4 +399,4 @@ const hcaptchaToken = async (url) => {
     return await solveCaptcha(captchaData[0], captchaData[1]);
 };
 
-module.exports = { hcaptcha, hcaptchaToken };
+module.exports = { hcaptcha, hcaptchaToken, solveCaptcha };


### PR DESCRIPTION
For non-regular pages (like API requests, or non-GET requests), it is helpful to be able to use just the `solveCaptcha` function.
Also, if for whatever reason you want to do a custom sitekey and/or host, you can do it this way.