### PR TITLE
Remove newassets from iframe selector

### DIFF
--- a/hcaptcha.js
+++ b/hcaptcha.js
@@ -342,12 +342,12 @@ const hcaptcha = async (page) => {
     await page.exposeFunction("solveCaptcha", solveCaptcha);
 
     // Wait for iframe to load
-    await page.waitForSelector('iframe[src*="newassets.hcaptcha.com"]');
+    await page.waitForSelector('iframe[src*="hcaptcha.com"]');
 
     const token = await page.evaluate(async () => {
         // Get hcaptcha iframe so we can get the host value
         const iframesrc = document.querySelector(
-            'iframe[src*="newassets.hcaptcha.com"]'
+            'iframe[src*="hcaptcha.com"]'
         ).src;
         const urlParams = new URLSearchParams(iframesrc);
 
@@ -381,12 +381,12 @@ const hcaptchaToken = async (url) => {
     await page.setDefaultNavigationTimeout(0);
 
     // Wait for iframe to load
-    await page.waitForSelector('iframe[src*="newassets.hcaptcha.com"]');
+    await page.waitForSelector('iframe[src*="hcaptcha.com"]');
 
     let captchaData = await page.evaluate(async () => {
         // Get hcaptcha iframe so we can get the host value
         const iframesrc = document.querySelector(
-            'iframe[src*="newassets.hcaptcha.com"]'
+            'iframe[src*="hcaptcha.com"]'
         ).src;
         const urlParams = new URLSearchParams(iframesrc);
 


### PR DESCRIPTION
This change removes the subdomain `newassets` from the iframe selectors.  The reason for the change is because the Cloudflare pages that I've seen on https://boxrec.com and https://www.escapefromtarkov.com/registration, both had iframes without `newassets`.  When the package tries to get the iframe, it'll fail.  This makes the selector for iframe less strict and prone to breakage.

I believe BoxRec didn't have a subdomain (didn't take screenshot), where the Tarkov website was instead under `cf-assets` as can be seen below.

| None of the iframes include `newassets` subdomain |
| - |
| <img width="1649" alt="chrome_cm6drKF2Q9" src="https://user-images.githubusercontent.com/5728044/180885378-2a0bb835-a8aa-4d8b-8bb0-f4220e5ebd96.png"> |

Everything else seems to be the same, like the version from JWT, it's still `newassets`.  The only thing that could potentially need updating is the `Origin` for the `checksiteconfig` endpoint.  I did see it with `cf-assets`.  I've left it as is for now, it worked unchanged.

| `cf-assets` in the `Origin`, where this package I've left as `newassets` |
| - |
| <img src="https://user-images.githubusercontent.com/5728044/180886188-c6dcc114-31fa-4bc4-b6f3-0b13093ff373.png" height="300px" /> |

Also while I'm here, do you know if there's a surefire way to re-trigger the Cloudflare captcha pages on websites?  I've passed the Cloudflare check on a certain website and I'd like to be able to go back to it.

Thanks
